### PR TITLE
Add integration test projects and base classes

### DIFF
--- a/BellaHair.Application.Tests/ApplicationTestBase.cs
+++ b/BellaHair.Application.Tests/ApplicationTestBase.cs
@@ -1,0 +1,45 @@
+﻿using BellaHair.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace BellaHair.Application.Tests
+{
+    // Mikkel Dahlmann
+
+    /// <summary>
+    /// Provides an abstract baseclass for integration testclasses in the applicationlayer.
+    /// Handles setup and disposure of database connection.
+    /// Ensures a clean-slate database for each test run.
+    /// </summary>
+   
+    public abstract class ApplicationTestBase
+    {
+        private DbContextOptions<BellaHairContext> _options;
+        private BellaHairContext _db;
+
+        // Setup af dbcontext ved start af test-suite. Gemmer kopi af test-database på C-drevet.
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _options = new DbContextOptionsBuilder<BellaHairContext>().UseSqlite("Data Source=\"C:\"").Options;
+            _db = new BellaHairContext(_options);
+            _db.Database.OpenConnection();
+            _db.Database.EnsureCreated();
+        }
+
+        // Setup ved hver kørte test. Sletter indholdet af database-filen, så testen kører på clean-slate.
+        [SetUp]
+        public void SetUp()
+        {
+            _db.Database.EnsureDeleted();
+            _db.Database.EnsureCreated();
+        }
+
+        // Afvikler forbindelsen til databasen ved test-suitens afslutning.
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _db.Database.CloseConnection();
+            _db.Dispose();
+        }
+    }
+}

--- a/BellaHair.Application.Tests/BellaHair.Application.Tests.csproj
+++ b/BellaHair.Application.Tests/BellaHair.Application.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BellaHair.Application\BellaHair.Application.csproj" />
+    <ProjectReference Include="..\BellaHair.Infrastructure\BellaHair.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/BellaHair.Infrastructure.Tests/InfrastructureTestBase.cs
+++ b/BellaHair.Infrastructure.Tests/InfrastructureTestBase.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace BellaHair.Infrastructure.Tests
+{
+    // Mikkel Dahlmann
+
+    /// <summary>
+    /// Provides an abstract baseclass for integration testclasses in the infrastructurelayer.
+    /// Handles setup and disposure of database connection.
+    /// Ensures a clean-slate database for each test run.
+    /// </summary>
+    
+    public abstract class InfrastructureTestBase
+    {
+        private DbContextOptions<BellaHairContext> _options;
+        private BellaHairContext _db;
+
+        // Setup af dbcontext ved start af test-suite. Gemmer kopi af test-database på C-drevet.
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _options = new DbContextOptionsBuilder<BellaHairContext>().UseSqlite("Data Source=\"C:\"").Options;
+            _db = new BellaHairContext(_options);
+            _db.Database.OpenConnection();
+            _db.Database.EnsureCreated();
+        }
+
+        // Setup ved hver kørte test. Sletter indholdet af database-filen, så testen kører på clean-slate.
+        [SetUp]
+        public void SetUp()
+        {
+            _db.Database.EnsureDeleted();
+            _db.Database.EnsureCreated();
+        }
+
+        // Afvikler forbindelsen til databasen ved test-suitens afslutning.
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _db.Database.CloseConnection();
+            _db.Dispose();
+        }
+    }
+}

--- a/BellaHair.sln
+++ b/BellaHair.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.36623.8
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11206.111 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BellaHair.Domain", "BellaHair.Domain\BellaHair.Domain.csproj", "{85ED2CFF-6447-4EB5-9EB1-A1EA1DC2E4B2}"
 EndProject
@@ -18,6 +18,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Testing", "Testing", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BellaHair.Infrastructure.Tests", "BellaHair.Infrastructure.Tests\BellaHair.Infrastructure.Tests.csproj", "{424C09C3-78B1-4157-88F9-C92FD8951BF6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BellaHair.Application.Tests", "BellaHair.Application.Tests\BellaHair.Application.Tests.csproj", "{6AD1D85E-9727-47DE-83DB-E5101A0EB8E6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +55,10 @@ Global
 		{424C09C3-78B1-4157-88F9-C92FD8951BF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{424C09C3-78B1-4157-88F9-C92FD8951BF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{424C09C3-78B1-4157-88F9-C92FD8951BF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6AD1D85E-9727-47DE-83DB-E5101A0EB8E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6AD1D85E-9727-47DE-83DB-E5101A0EB8E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6AD1D85E-9727-47DE-83DB-E5101A0EB8E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6AD1D85E-9727-47DE-83DB-E5101A0EB8E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,6 +66,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{76F00F9C-304A-4615-8FDC-7C4DFF490774} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{424C09C3-78B1-4157-88F9-C92FD8951BF6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{6AD1D85E-9727-47DE-83DB-E5101A0EB8E6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {21C7DBC5-D7B0-4152-8052-244167D0C8C4}


### PR DESCRIPTION
- [ ] Navngivning
    - Klasser
    - Records
    - Interface
    - Properties
    - Fields
    - Metodenavne
    - Metodeparametre
    - Primære constructors på klasser
    - Primære constructors på records

- [ ] Placering
    - Entiteter
    - Repository interfaces
    - Repository implementeringer
    - CommandHandler interfaces
    - CommandHandler implementeringer
    - QueryHandler interfaces
    - QueryHandler implementeringer
    - Commands
    - Queries

- [ ] Blazor
    - Er lokale (bruges kun i en enkelt komponent) css klasser i komponentens egen css fil?
    - Anvendes globale css klasser til alle komponenter som skal se ens ud?
     
- [ ] Exceptions
    - Anvendes klasse-specifikke exceptions?
    - Fanges alle exceptions i præsentationslaget?

- [ ] Er koden kommenteret?
    - Hvor koden ikke er gennemskuelig
    - Hvor kodebeslutningen skal begrundes

- [ ] Udviklernavn på klasser
- [ ] Er der skrevet summaries til typer og metoder?
- [ ] Er der skrevet ADR'er på væsentlige beslutninger?
- [ ] Skal der skrives resultatafsnit over features i denne PR?
- [ ] Er metoder som skal være public public, og private private?
- [ ] Er properties og fields som skal være nullable nullable?
- [ ] Fanges alle exceptions?

#### Domain
- [ ] Invarianter
- [ ] Er property getters og setters sat korrekt
    - private set på klasser
    - private init på records

- [ ] Er domæne model opdateret med ændringer til entiteter?


Add integration test projects and base classes

Added a new `BellaHair.Application.Tests` project to the solution for testing the application layer. Updated `BellaHair.sln` to include the new project, configured build settings, and nested it under the `Testing` folder.

Introduced `ApplicationTestBase` and `InfrastructureTestBase` abstract classes to facilitate integration testing for the application and infrastructure layers. These classes handle SQLite database setup, teardown, and ensure a clean state for each test run.

Created `BellaHair.Application.Tests.csproj` targeting `.NET 9.0` with dependencies for testing, including `NUnit` and `EntityFrameworkCore`. Updated the solution to use Visual Studio 18.3.